### PR TITLE
Standardize on unknown source

### DIFF
--- a/data/102/534/731/102534731.geojson
+++ b/data/102/534/731/102534731.geojson
@@ -18,7 +18,7 @@
         "PBX",
         "KPBX"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424768,
@@ -37,7 +37,7 @@
         "icao:code":"KPBX"
     },
     "wof:country":"BR",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102534731,
@@ -46,7 +46,7 @@
         }
     ],
     "wof:id":102534731,
-    "wof:lastmodified":1566618687,
+    "wof:lastmodified":1589218812,
     "wof:name":"Aeroporto Porto Alegre do Norte",
     "wof:parent_id":85681955,
     "wof:placetype":"campus",
@@ -63,5 +63,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst/whosonfirst-sources/issues/112.

Swaps any "missing" values in `src:geom` properties to "unknown". I also checked values in `src:geom_alt` and `wof:geom_alt` properties, but there were no cases.

No PIP required, can merge once approved.